### PR TITLE
Some Tweaks to the InstallSitePackage installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,7 @@
         "neos/site-kickstarter": "@dev",
 
         "neos/neos-ui": "@dev",
-        "neos/seo": "@dev",
         "neos/fusion-afx": "@dev",
-        "neos/redirecthandler-neosadapter": "@dev",
-        "neos/redirecthandler-databasestorage": "@dev",
 
         "neos/setup": "@dev",
         "neos/neos-setup": "@dev"


### PR DESCRIPTION
* Apply cosmetic fixes from #42 (typos, unused namespace imports, ...)
* Extract installable "distributions" to static method (to make it
  easier to adjust/extend)
* Replace "empty Neos" with a bare bones installation that only contains
  the necessary packages